### PR TITLE
chore: include subset in collection name to support environment-specific embeddings. Use 'stable' as default subset.

### DIFF
--- a/lmos-classifier-core/src/main/kotlin/org/eclipse/lmos/classifier/core/AgentClassifier.kt
+++ b/lmos-classifier-core/src/main/kotlin/org/eclipse/lmos/classifier/core/AgentClassifier.kt
@@ -46,10 +46,12 @@ data class InputContext(
  *
  * @property tenantId The identifier for the tenant.
  * @property channelId The identifier for the channel.
+ * @property channelId The identifier for the subset, default is 'stable'.
  */
 data class SystemContext(
     val tenantId: String,
     val channelId: String,
+    val subset: String = "stable",
 )
 
 /**

--- a/lmos-classifier-vector/src/main/kotlin/org/eclipse/lmos/classifier/vector/retriever/QdrantEmbeddingRetriever.kt
+++ b/lmos-classifier-vector/src/main/kotlin/org/eclipse/lmos/classifier/vector/retriever/QdrantEmbeddingRetriever.kt
@@ -37,7 +37,7 @@ class QdrantEmbeddingRetriever(
             val embeddings = contents.mapNotNull { it.convert() }
             return embeddings
         } catch (e: RuntimeException) {
-            throw TenantNotSupportedException("No collection found for tenant '${context.tenantId}' and channel '${context.channelId}'.", e)
+            throw TenantNotSupportedException("Collection '$collection' not found.", e)
         }
     }
 

--- a/lmos-classifier-vector/src/main/kotlin/org/eclipse/lmos/classifier/vector/utils/Utility.kt
+++ b/lmos-classifier-vector/src/main/kotlin/org/eclipse/lmos/classifier/vector/utils/Utility.kt
@@ -69,4 +69,4 @@ fun List<Embedding>.convertEmbeddingsToAgents(): List<Agent> =
             )
         }
 
-fun getQdrantCollectionName(context: SystemContext) = "${context.tenantId}-${context.channelId}"
+fun getQdrantCollectionName(context: SystemContext) = "${context.tenantId}-${context.channelId}-${context.subset}"

--- a/lmos-classifier-vector/src/test/kotlin/org/eclipse/lmos/classifier/vector/retriever/QdrantEmbeddingRetrieverIntegrationTest.kt
+++ b/lmos-classifier-vector/src/test/kotlin/org/eclipse/lmos/classifier/vector/retriever/QdrantEmbeddingRetrieverIntegrationTest.kt
@@ -130,7 +130,7 @@ class QdrantEmbeddingRetrieverIntegrationTest {
         val context = SystemContext("tenant-does-not-exist", "test-channel")
         assertThatThrownBy { underTest.retrieve(context, "some query") }
             .isInstanceOf(TenantNotSupportedException::class.java)
-            .hasMessage("No collection found for tenant '${context.tenantId}' and channel '${context.channelId}'.")
+            .hasMessage("Collection '${context.tenantId}-${context.channelId}-${context.subset}' not found.")
     }
 
     private fun createPoint(


### PR DESCRIPTION
Include subset in collection name to support environment-specific embeddings. Use 'stable' as default subset.